### PR TITLE
[feature-04] 내 정보 조회 기능

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21"
     kotlin("plugin.jpa") version "1.6.21"
+    kotlin("kapt") version "1.6.21"
 }
 
 group = "com.project"
@@ -30,13 +31,23 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
+    implementation("com.querydsl:querydsl-jpa")
+    kapt(group = "com.querydsl", name = "querydsl-apt", classifier = "jpa")
+    kapt("org.springframework.boot:spring-boot-configuration-processor")
+
     runtimeOnly("mysql:mysql-connector-java")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
 }
 
 allOpen {
     annotations("javax.persistence.Entity", "javax.persistence.MappedSuperclass")
+}
+
+val querydslDir = "$buildDir/generated/source/kapt/main"
+sourceSets.main {
+    setBuildDir(querydslDir)
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/project/myservice/application/user/UserService.kt
+++ b/src/main/kotlin/com/project/myservice/application/user/UserService.kt
@@ -70,4 +70,8 @@ class UserService(
             UserPasswordResetEvent(UserInfo.of(user), command.newPassword)
         )
     }
+
+    @Transactional(readOnly = true)
+    fun findUserDetail(username: String) =
+        userRepository.findDetail(username) ?: throw UserNotFoundException()
 }

--- a/src/main/kotlin/com/project/myservice/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/project/myservice/common/exception/ErrorCode.kt
@@ -5,6 +5,7 @@ enum class ErrorCode(
 ) {
     COMMON_SYSTEM_ERROR("시스템에서 오류가 발생했습니다"),
     COMMON_INVALID_PARAMETER("요청한 값이 올바르지 않습니다"),
+    COMMON_INVALID_TOKEN("토큰 정보가 올바르지 않습니다"),
 
     USER_ALREADY_EXISTS("회원정보가 존재합니다"),
     USER_NOT_FOUND("회원정보를 찾을 수 없습니다"),

--- a/src/main/kotlin/com/project/myservice/config/jpa/QuerydslConfig.kt
+++ b/src/main/kotlin/com/project/myservice/config/jpa/QuerydslConfig.kt
@@ -1,0 +1,16 @@
+package com.project.myservice.config.jpa
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QuerydslConfig(
+    @PersistenceContext val entityManager: EntityManager,
+) {
+
+    @Bean
+    fun queryFactory() = JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/com/project/myservice/config/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/project/myservice/config/security/SecurityConfig.kt
@@ -31,6 +31,8 @@ class SecurityConfig {
             .permitAll()
             .antMatchers(HttpMethod.POST, "/api/v1/users", "/api/v1/users/reset-password")
             .permitAll()
+            .antMatchers(HttpMethod.GET, "/api/v1/users/**")
+            .hasAnyAuthority("ROLE_ADMIN", "ROLE_USER")
             .anyRequest()
             .authenticated()
         http.addFilter(customAuthenticationFilter)

--- a/src/main/kotlin/com/project/myservice/config/security/filter/CustomAuthenticationFilter.kt
+++ b/src/main/kotlin/com/project/myservice/config/security/filter/CustomAuthenticationFilter.kt
@@ -2,6 +2,7 @@ package com.project.myservice.config.security.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.project.myservice.config.security.token.TokenManager
+import com.project.myservice.presentation.common.CommonResponse
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -47,11 +48,10 @@ class CustomAuthenticationFilter(
             iss = request?.requestURI.toString(),
             roles = user.authorities.map { it.authority }.toList()
         )
-        val tokens: Map<String, String> = mapOf("access_token" to tokenInfo.accessToken)
 
         response?.let {
             it.contentType = MediaType.APPLICATION_JSON_VALUE
-            ObjectMapper().writeValue(it.outputStream, tokens)
+            ObjectMapper().writeValue(it.outputStream, CommonResponse.success(tokenInfo))
         }
     }
 }

--- a/src/main/kotlin/com/project/myservice/config/security/filter/CustomAuthorizationFilter.kt
+++ b/src/main/kotlin/com/project/myservice/config/security/filter/CustomAuthorizationFilter.kt
@@ -1,7 +1,9 @@
 package com.project.myservice.config.security.filter
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.project.myservice.common.exception.ErrorCode
 import com.project.myservice.config.security.token.TokenManager
+import com.project.myservice.presentation.common.CommonResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -50,9 +52,11 @@ class CustomAuthorizationFilter : OncePerRequestFilter() {
                 response.status = HttpStatus.FORBIDDEN.value()
                 response.contentType = MediaType.APPLICATION_JSON_VALUE
                 e.message?.let {
-                    val error = mutableMapOf<String, String>()
-                    error["error_message"] = e.message ?: ""
-                    ObjectMapper().writeValue(response.outputStream, error)
+                    val errorResponse = CommonResponse.fail(
+                        ErrorCode.COMMON_INVALID_TOKEN.name,
+                        e.message ?: ErrorCode.COMMON_INVALID_TOKEN.errorMessage
+                    )
+                    ObjectMapper().writeValue(response.outputStream, errorResponse)
                 }
             }
         } else {

--- a/src/main/kotlin/com/project/myservice/domain/user/UserDetailInfo.kt
+++ b/src/main/kotlin/com/project/myservice/domain/user/UserDetailInfo.kt
@@ -1,0 +1,16 @@
+package com.project.myservice.domain.user
+
+import java.time.Instant
+
+data class UserDetailInfo(
+    val id: Long,
+    val username: String,
+    val email: String,
+    val phoneNumber: String,
+    val name: String,
+    val nickname: String,
+    val roles: List<String>,
+    val createdAt: Instant,
+    val updatedAt: Instant?,
+    val deletedAt: Instant?,
+)

--- a/src/main/kotlin/com/project/myservice/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/project/myservice/domain/user/UserRepository.kt
@@ -9,4 +9,6 @@ interface UserRepository {
     fun findByEmail(email: String): User?
 
     fun findByPhoneNumber(phoneNumber: String): User?
+
+    fun findDetail(username: String): UserDetailInfo?
 }

--- a/src/main/kotlin/com/project/myservice/infrastructure/user/DefaultUserRepository.kt
+++ b/src/main/kotlin/com/project/myservice/infrastructure/user/DefaultUserRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository
 @Repository
 class DefaultUserRepository(
     val jpaUserRepository: JpaUserRepository,
+    val jpaUserQueryRepository: JpaUserQueryRepository,
 ) : UserRepository {
 
     override fun save(user: User) = jpaUserRepository.save(user)
@@ -17,4 +18,6 @@ class DefaultUserRepository(
 
     override fun findByPhoneNumber(phoneNumber: String) =
         jpaUserRepository.findByPhoneNumber(phoneNumber)
+
+    override fun findDetail(username: String) = jpaUserQueryRepository.findDetail(username)
 }

--- a/src/main/kotlin/com/project/myservice/infrastructure/user/JpaUserQueryRepository.kt
+++ b/src/main/kotlin/com/project/myservice/infrastructure/user/JpaUserQueryRepository.kt
@@ -1,0 +1,46 @@
+package com.project.myservice.infrastructure.user
+
+import com.project.myservice.domain.user.QRole.role
+import com.project.myservice.domain.user.QUser.user
+import com.project.myservice.domain.user.UserDetailInfo
+import com.querydsl.core.group.GroupBy
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class JpaUserQueryRepository(
+    val queryFactory: JPAQueryFactory
+) {
+
+    fun findDetail(username: String): UserDetailInfo? {
+        return queryFactory
+            .from(user)
+            .innerJoin(role).on(user.roleIds.contains(role.id)).fetchJoin()
+            .where(user.username.eq(username))
+            .transform(
+                GroupBy.groupBy(user.id).list(
+                    Projections.constructor(
+                        UserDetailInfo::class.java,
+                        user.id,
+                        user.username,
+                        user.email,
+                        user.phoneNumber,
+                        user.name,
+                        user.nickname,
+                        GroupBy.list(
+                            Projections.constructor(
+                                String::class.java,
+                                role.name
+                            )
+                        ),
+                        user.createdAt,
+                        user.updatedAt,
+                        user.deletedAt
+                    )
+                )
+            ).let {
+                if (it.size >= 1) it[0] else null
+            }
+    }
+}

--- a/src/main/kotlin/com/project/myservice/presentation/user/UserController.kt
+++ b/src/main/kotlin/com/project/myservice/presentation/user/UserController.kt
@@ -3,10 +3,8 @@ package com.project.myservice.presentation.user
 import com.project.myservice.application.user.UserService
 import com.project.myservice.presentation.common.CommonResponse
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import java.security.Principal
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -30,5 +28,12 @@ class UserController(
         userService.resetPassword(request.toCommand())
 
         return CommonResponse.success()
+    }
+
+    @GetMapping("/my")
+    fun findMyInfo(principal: Principal): CommonResponse<UserDetailInfoDto> {
+        val userDetailInfo = userService.findUserDetail(principal.name)
+
+        return CommonResponse.success(UserDetailInfoDto.of(userDetailInfo))
     }
 }

--- a/src/main/kotlin/com/project/myservice/presentation/user/UserDto.kt
+++ b/src/main/kotlin/com/project/myservice/presentation/user/UserDto.kt
@@ -3,6 +3,7 @@ package com.project.myservice.presentation.user
 import com.project.myservice.application.user.CreateUserCommand
 import com.project.myservice.application.user.ResetPasswordCommand
 import com.project.myservice.common.util.toLocalString
+import com.project.myservice.domain.user.UserDetailInfo
 import com.project.myservice.domain.user.UserInfo
 import javax.validation.constraints.Email
 import javax.validation.constraints.NotBlank
@@ -102,6 +103,36 @@ data class UserInfoDto(
                 createdAt = userInfo.createdAt.toLocalString(),
                 updatedAt = userInfo.updatedAt?.toLocalString(),
                 deletedAt = userInfo.deletedAt?.toLocalString()
+            )
+        }
+    }
+}
+
+data class UserDetailInfoDto(
+    val id: Long,
+    val username: String,
+    val email: String,
+    val phoneNumber: String,
+    val name: String,
+    val nickname: String,
+    val roles: List<String>,
+    val createdAt: String,
+    val updatedAt: String?,
+    val deletedAt: String?,
+) {
+    companion object {
+        fun of(userDetailInfo: UserDetailInfo): UserDetailInfoDto {
+            return UserDetailInfoDto(
+                id = userDetailInfo.id,
+                username = userDetailInfo.username,
+                email = userDetailInfo.email,
+                phoneNumber = userDetailInfo.phoneNumber,
+                name = userDetailInfo.name,
+                nickname = userDetailInfo.nickname,
+                roles = userDetailInfo.roles,
+                createdAt = userDetailInfo.createdAt.toLocalString(),
+                updatedAt = userDetailInfo.updatedAt?.toLocalString(),
+                deletedAt = userDetailInfo.deletedAt?.toLocalString()
             )
         }
     }

--- a/src/main/kotlin/com/project/myservice/presentation/user/UserDto.kt
+++ b/src/main/kotlin/com/project/myservice/presentation/user/UserDto.kt
@@ -84,9 +84,10 @@ data class ResetPasswordRequestDto(
 
 data class UserInfoDto(
     val id: Long,
+    val username: String,
     val email: String,
     val phoneNumber: String,
-    val username: String,
+    val name: String,
     val nickname: String,
     val createdAt: String,
     val updatedAt: String?,
@@ -96,9 +97,10 @@ data class UserInfoDto(
         fun of(userInfo: UserInfo): UserInfoDto {
             return UserInfoDto(
                 id = userInfo.id,
+                username = userInfo.username,
                 email = userInfo.email,
                 phoneNumber = userInfo.phoneNumber,
-                username = userInfo.username,
+                name = userInfo.name,
                 nickname = userInfo.nickname,
                 createdAt = userInfo.createdAt.toLocalString(),
                 updatedAt = userInfo.updatedAt?.toLocalString(),

--- a/src/test/kotlin/com/project/myservice/domain/user/LocalUserRepository.kt
+++ b/src/test/kotlin/com/project/myservice/domain/user/LocalUserRepository.kt
@@ -3,7 +3,9 @@ package com.project.myservice.domain.user
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicLong
 
-class LocalUserRepository: UserRepository {
+class LocalUserRepository(
+    val localRoleRepository: LocalRoleRepository? = null
+): UserRepository {
 
     val data = mutableListOf<User>()
     var lastId = AtomicLong(1)
@@ -36,5 +38,26 @@ class LocalUserRepository: UserRepository {
     override fun findByPhoneNumber(phoneNumber: String): User? {
         val findUsers = data.filter { it.phoneNumber == phoneNumber }.toList()
         return if (findUsers.isNotEmpty()) findUsers[0] else null
+    }
+
+    override fun findDetail(username: String): UserDetailInfo? {
+        val findUsers = data.filter { it.username == username }.toList()
+        if (findUsers.isEmpty()) return null
+
+        val findUser = findUsers[0]
+        val userRoles = localRoleRepository?.findByIds(findUser.roleIds)
+
+        return UserDetailInfo(
+            findUser.id!!,
+            findUser.username,
+            findUser.email,
+            findUser.phoneNumber,
+            findUser.name,
+            findUser.nickname,
+            userRoles?.map { it.name }?.toList() ?: listOf(),
+            findUser.createdAt!!,
+            findUser.updatedAt,
+            findUser.deletedAt
+        )
     }
 }

--- a/src/test/kotlin/com/project/myservice/presentation/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/project/myservice/presentation/user/UserControllerTest.kt
@@ -567,7 +567,7 @@ internal class UserControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("errorCode").value("COMMON_INVALID_PARAMETER"))
                 .andExpect(
                     MockMvcResultMatchers.jsonPath("message")
-                        .value("요청한 'phoneNumber' 값이 올바르지 않습니다. 입력 값: '$phoneNumber'. 전화번호는 공백일 수 없습니다"))
+                        .value("요청한 'phoneNumber' 값이 올바르지 않습니다. 입력 값: '$phoneNumber'. 전화번호는 10~11자리 숫자만 입력 가능합니다"))
         }
 
         @ParameterizedTest


### PR DESCRIPTION
### Description
내 정보를 조회하는 기능 개발

### 수정 내역
회원의 상세 정보를 조회하는 기능 추가
- 내 정보는 로그인 token을 이용해서 조회 가능하기 때문에, 별도로 resourceId를 받아서 처리하지 않는다
- User Entity외에 다른 Entity와 Join한 결과를 가져올 수 있도록 별도의 QueryRepository 추가
- 쿼리 조회 결과를 Entity가 아니라 별도의 조회 모델(=UserDetailInfo)를 이용해서 응답하도록 처리

### 결과
내 정보를 조회할 수 있다